### PR TITLE
ChemistryHelp Bot Same Message Mentions  Fix

### DIFF
--- a/axiol/custom/742737352799289375.py
+++ b/axiol/custom/742737352799289375.py
@@ -430,6 +430,18 @@ class ChemistryHelp(commands.Cog):
             user_id = str(message.author.id)
             current_time = time.time()
 
+            if len(mentions) >= 3:
+                dict_mentions = []
+                for mention in mentions:
+                    mention_id = mention[3:-1]
+                    if mention_id not in dict_mentions:
+                        dict_mentions.append(mention_id)
+                if len(dict_mentions) >= 3:
+                    await message.channel.send(f"{message.author.mention}, please do not spam mentions.")
+                    await message.delete()
+                    await member.add_roles(disnake.utils.get(message.guild.roles, id=742801455010021387)) # Insert Role ID (Muted Role)
+                    return
+
             if user_id in last_action:
                 last_action[user_id]['time'].append(current_time)
                 last_action[user_id]['messages'].append(message)


### PR DESCRIPTION
Added 12 lines of code. 

The bot uses an already implemented list of mentions that has been parsed from the message content. I use that list to create a "dictionary" of different people mentioned within a message and check if there are more or equal to three different people mentioned. If there are the bot verbally warns, deletes the message, and add a mute role to the user. 